### PR TITLE
Reduce the probability of getting concave/flared stems

### DIFF
--- a/parameters.json
+++ b/parameters.json
@@ -351,21 +351,21 @@
          "url":"parameters.html#stems",
          "level":3,
          "name":"slightly concave",
-         "weight":10,
+         "weight":4,
          "description":"The stems are slightly curved inward. Reversed entasis."
       },
       {  
          "url":"parameters.html#stems",
          "level":4,
          "name":"visibly concave",
-         "weight":10,
+         "weight":4,
          "description":"The stems are visibly curved inward. Reversed entasis."
       },
       {  
          "url":"parameters.html#stems",
          "level":4,
          "name":"flaring",
-         "weight":10,
+         "weight":4,
          "description":"The stems are very much curved inward. Might involve serifs."
       },
       {  


### PR DESCRIPTION
Hi,
The weighting of the stem parameter seems a bit skewed towards concave/flared stems. These are fun but I think they should be a bit more rare. I reduced the weight for "Slightly concave", "Visibly concave" and "Flaring" to 4, I think it's more balanced that way.